### PR TITLE
18 Fix comment window closes on MouseUp event

### DIFF
--- a/src/app/admin/events/event-notifications-edit-modal.component.html
+++ b/src/app/admin/events/event-notifications-edit-modal.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div bsModal #modal="bs-modal" class="modal" tabindex="-1" role="dialog">
+<div bwsModal #modal="bws-modal" class="modal" tabindex="-1" role="dialog">
   <div class="modal-dialog">
     <div class="modal-content">
 

--- a/src/app/admin/events/event-notifications-edit-modal.component.ts
+++ b/src/app/admin/events/event-notifications-edit-modal.component.ts
@@ -14,11 +14,11 @@
 
 import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { EventModel, EventNotificationKind, EventRecipient, IEventNotification } from '../../core/models/event-model';
-import { ModalDirective } from 'ngx-bootstrap';
 import { AdminEventService } from '../../core/services/admin-event.service';
 import * as moment from 'moment';
 import { ValidatorFutureDate } from '../../shared/components/datetime/datetime-picker.component';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ModalDirective } from '../../shared/components/modal/modal.directive';
 
 @Component({
   selector: 'bs-assessment-event-notifications-edit-modal',

--- a/src/app/admin/events/projects-add-modal.component.html
+++ b/src/app/admin/events/projects-add-modal.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div bsModal #modal="bs-modal" class="modal" tabindex="-1" role="dialog">
+<div bwsModal #modal="bws-modal" class="modal" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
 

--- a/src/app/admin/events/projects-add-modal.component.ts
+++ b/src/app/admin/events/projects-add-modal.component.ts
@@ -15,7 +15,6 @@
 import { forkJoin as observableForkJoin } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
-import { ModalDirective } from 'ngx-bootstrap';
 import { ModelId } from '../../core/models/model';
 import { NotificationService } from '../../core/services/notification.service';
 import { IListResponse } from '../../core/services/rest.service';
@@ -23,6 +22,7 @@ import { ProjectModel } from '../../core/models/project-model';
 import { AdminProjectService } from '../../core/services/admin-project.service';
 import { AdminEventService } from '../../core/services/admin-event.service';
 import { TranslateService } from '@ngx-translate/core';
+import { ModalDirective } from '../../shared/components/modal/modal.directive';
 import { Utils } from '../../utils';
 
 interface ISelectProject {

--- a/src/app/admin/groups/users-add-modal.component.html
+++ b/src/app/admin/groups/users-add-modal.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div bsModal #modal="bs-modal" class="modal" tabindex="-1" role="dialog">
+<div bwsModal #modal="bws-modal" class="modal" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
 

--- a/src/app/admin/groups/users-add-modal.component.ts
+++ b/src/app/admin/groups/users-add-modal.component.ts
@@ -15,13 +15,13 @@
 import { forkJoin as observableForkJoin } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { ModalDirective } from 'ngx-bootstrap';
 import { ModelId } from '../../core/models/model';
 import { UserModel, UserStatus } from '../../core/models/user-model';
 import { AdminGroupService } from '../../core/services/admin-group.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { IListResponse } from '../../core/services/rest.service';
 import { AdminUserService } from '../../core/services/admin-user.service';
+import { ModalDirective } from '../../shared/components/modal/modal.directive';
 import { Utils } from '../../utils';
 import { TranslateService } from '@ngx-translate/core';
 

--- a/src/app/admin/projects/email-templates-add-modal.component.html
+++ b/src/app/admin/projects/email-templates-add-modal.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div bsModal #modal="bs-modal" class="modal" tabindex="-1" role="dialog">
+<div bwsModal #modal="bws-modal" class="modal" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">

--- a/src/app/admin/projects/email-templates-add-modal.component.ts
+++ b/src/app/admin/projects/email-templates-add-modal.component.ts
@@ -13,10 +13,10 @@
  */
 
 import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { ModalDirective } from 'ngx-bootstrap';
 import { EmailKind, EmailTemplateModel } from '../../core/models/email-template-model';
 import { IEmailTemplate } from '../../core/models/project-model';
 import { AdminEmailTemplateService } from '../../core/services/admin-email-template.service';
+import { ModalDirective } from '../../shared/components/modal/modal.directive';
 
 @Component({
   selector: 'bs-email-templates-add-modal',

--- a/src/app/shared/components/image-uploader/image-uploader.component.html
+++ b/src/app/shared/components/image-uploader/image-uploader.component.html
@@ -22,7 +22,7 @@
         (click)="choosePictureInput.click();"> {{ 'T_USER_AVATAR_UPLOAD' | translate }}
 </button>
 
-<div class="modal" bsModal #cropperModal="bs-modal"
+<div class="modal" bwsModal #cropperModal="bws-modal"
      [config]="{ ignoreBackdropClick: true }"
      tabindex="3" role="dialog">
   <div class="modal-dialog modal-lg">

--- a/src/app/shared/components/image-uploader/image-uploader.component.ts
+++ b/src/app/shared/components/image-uploader/image-uploader.component.ts
@@ -13,9 +13,9 @@
  */
 
 import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { ModalDirective } from 'ngx-bootstrap';
 import { Observable } from 'rxjs';
 import cropperjs from 'cropperjs';
+import { ModalDirective } from '../modal/modal.directive';
 
 @Component({
   selector: 'bs-image-uploader',

--- a/src/app/shared/components/modal/modal.directive.ts
+++ b/src/app/shared/components/modal/modal.directive.ts
@@ -1,0 +1,101 @@
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+  Renderer2,
+  ViewContainerRef
+} from '@angular/core';
+import {
+  ComponentLoaderFactory,
+  ModalDirective as BootstrapModalDirective,
+  ModalOptions
+} from 'ngx-bootstrap';
+
+export interface IDismissReasons {
+  BACKRDOP: string;
+  ESC: string;
+}
+
+export const DISMISS_REASONS: IDismissReasons = {
+  BACKRDOP: 'backdrop-click',
+  ESC: 'esc'
+};
+
+/**
+ * ModalDirective should be removed as soon as ngx-bootstrap dependency will update to version 5.x or upper.
+ * Current implementation has solution that solves problem with closing window on mouseup events which are happens outside of modal window.
+ */
+@Directive({
+  selector: '[bwsModal]',
+  exportAs: 'bws-modal'
+})
+export class ModalDirective extends BootstrapModalDirective {
+  /** This event fires immediately when the `show` instance method is called. */
+  @Output()
+  public onShow: EventEmitter<ModalDirective> = new EventEmitter<ModalDirective>();
+
+  /** This event is fired when the modal has been made visible to the user
+   * (will wait for CSS transitions to complete)
+   */
+  @Output()
+  public onShown: EventEmitter<ModalDirective> = new EventEmitter<ModalDirective>();
+
+  /** This event is fired immediately when the hide instance method has been called. */
+  @Output()
+  public onHide: EventEmitter<ModalDirective> = new EventEmitter<ModalDirective>();
+
+  /** This event is fired when the modal has finished being
+   * hidden from the user (will wait for CSS transitions to complete).
+   */
+  @Output()
+  public onHidden: EventEmitter<ModalDirective> = new EventEmitter<ModalDirective>();
+
+  private _clickStartedInContent = false;
+
+  /** allows to set modal configuration via element property */
+  /** Added to fix LanguageService in templates */
+  @Input()
+  set config(conf: ModalOptions) {
+    this._config = this.getConfig(conf);
+  }
+
+  get config(): ModalOptions {
+    return this._config;
+  }
+
+  constructor(viewContainerRef: ViewContainerRef,
+              renderer: Renderer2,
+              clf: ComponentLoaderFactory,
+              private _el: ElementRef) {
+    super(_el, viewContainerRef, renderer, clf);
+  }
+
+  @HostListener('mousedown', ['$event'])
+  public onClickStarted(event: MouseEvent): void {
+    this._clickStartedInContent = event.target !== this._el.nativeElement;
+  }
+
+  @HostListener('mouseup', ['$event'])
+  public onClickStop(event: MouseEvent): void {
+    const clickedInBackdrop = event.target === this._el.nativeElement && !this._clickStartedInContent;
+    if (
+      this.config.ignoreBackdropClick ||
+      this.config.backdrop === 'static' ||
+      !clickedInBackdrop
+    ) {
+      this._clickStartedInContent = false;
+
+      return;
+    }
+    this.dismissReason = DISMISS_REASONS.BACKRDOP;
+    this.hide(event);
+  }
+
+  @HostListener('click', ['$event'])
+  public onClick(event: MouseEvent): void {
+    return;
+  }
+}

--- a/src/app/shared/confirmation/confirmation.component.html
+++ b/src/app/shared/confirmation/confirmation.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div bsModal #modal="bs-modal" [config]="{ show: true }"
+<div bwsModal #modal="bws-modal" [config]="{ show: true }"
      class="modal text-left" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content confirmation-modal-content" [ngSwitch]="!!conflicts">

--- a/src/app/shared/confirmation/confirmation.component.ts
+++ b/src/app/shared/confirmation/confirmation.component.ts
@@ -13,9 +13,9 @@
  */
 
 import { Component, Input, OnInit, TemplateRef, ViewChild } from '@angular/core';
-import { ModalDirective } from 'ngx-bootstrap';
 import { Subject } from 'rxjs';
 import { IConflicts } from '../../core/services/confirmation.service';
+import { ModalDirective } from '../components/modal/modal.directive';
 
 @Component({
   selector: 'bs-confirmation-modal',

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -27,6 +27,7 @@ import {
   TabsModule, TooltipModule
 } from 'ngx-bootstrap';
 import { FiltersComponent } from './components/filters/filters.component';
+import { ModalDirective } from './components/modal/modal.directive';
 import { ConfirmationDirective } from './directives/confirmation.directive';
 import { ToastrModule } from 'ngx-toastr';
 import { PaginationComponent } from './components/pagination/pagination.component';
@@ -71,6 +72,7 @@ import { NgSelectModule } from '@ng-select/ng-select';
   ],
   declarations: [
     ConfirmationDirective,
+    ModalDirective,
     FiltersComponent,
     PaginationComponent,
     DateTimeComponent,
@@ -116,7 +118,8 @@ import { NgSelectModule } from '@ng-select/ng-select';
     FormsModule,
     ConfirmationModalComponent,
     LikesDislikesComponent,
-    ImageUploaderComponent
+    ImageUploaderComponent,
+    ModalDirective,
   ],
   entryComponents: [ConfirmationModalComponent]
 })

--- a/src/app/user-event/assessment-form-modal.component.html
+++ b/src/app/user-event/assessment-form-modal.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div bsModal #commentModal="bs-modal" class="modal" tabindex="-1" role="dialog">
+<div bwsModal #commentModal="bws-modal" class="modal" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
 

--- a/src/app/user-event/assessment-form-modal.component.ts
+++ b/src/app/user-event/assessment-form-modal.component.ts
@@ -13,8 +13,8 @@
  */
 
 import { Component, EventEmitter, Output, ViewChild } from '@angular/core';
-import { ModalDirective } from 'ngx-bootstrap';
 import { FormElement } from '../core/models/form-model';
+import { ModalDirective } from '../shared/components/modal/modal.directive';
 import { IComment } from './assessment-form.component';
 
 @Component({


### PR DESCRIPTION
Root cause of problem in ngx-bootstrap `ModalDirective` and it processing of clicks. In new versions (5.x) it's already fixed, but updating such heavily used library may cause a lot of hidden bugs without re-testing.

So I decided to extends current version of ModalDirective.