### PR TITLE
27 Bugfix anonymity reset on form clear

### DIFF
--- a/src/app/user-event/assessment-form.component.html
+++ b/src/app/user-event/assessment-form.component.html
@@ -388,11 +388,13 @@
                  [disabled]="status !== EventStatus.InProgress || ((!canRevote && isAnswered))"
                  #anonymous="ngModel"
                  [ngModel]="isAnonymous"
+                 [ngModelOptions]="{standalone: true}"
                  (ngModelChange)="isAnonymous = $event; onFormChange();">
           <span class="switch-label"></span>
           <span class="switch-handle"></span>
         </label>
       </div>
+
       <div class="form-submit-buttons"
            *ngIf="(status === EventStatus.InProgress && !inline) && (!(!canRevote && isAnswered) || canRevote)">
         <button type="button"


### PR DESCRIPTION
Root cause: Clear button was triggering assessment form reset. Anonymity switch was placed in `<form>` tag and so was also clearing.
Solution: Anonymity switch made standalone.