### PR TITLE
28 Fix bubbling of click event in modal and confirmation modal components

### DIFF
--- a/src/app/shared/components/modal/modal.directive.ts
+++ b/src/app/shared/components/modal/modal.directive.ts
@@ -30,7 +30,7 @@ export const DISMISS_REASONS: IDismissReasons = {
  */
 @Directive({
   selector: '[bwsModal]',
-  exportAs: 'bws-modal'
+  exportAs: 'bws-modal',
 })
 export class ModalDirective extends BootstrapModalDirective {
   /** This event fires immediately when the `show` instance method is called. */
@@ -96,6 +96,6 @@ export class ModalDirective extends BootstrapModalDirective {
 
   @HostListener('click', ['$event'])
   public onClick(event: MouseEvent): void {
-    return;
+    event.stopPropagation();
   }
 }

--- a/src/app/shared/directives/confirmation.directive.ts
+++ b/src/app/shared/directives/confirmation.directive.ts
@@ -44,7 +44,9 @@ export class ConfirmationDirective {
   }
 
   @HostListener('click', ['$event'])
-  public clickHandler() {
+  public clickHandler(event: UIEvent): void {
+    event.stopPropagation();
+
     this._confirmationService.setViewContainerRef(this._viewContainerRef);
     this._confirmationService.loadTemplate(this._contentTemplate);
 


### PR DESCRIPTION
__Root cause__: Click event from delete button and from modal window is bubbling up and catches by Accordion component, which is toggling itself state.