### PR TITLE
32 Fix validation and error displaying for datetime picker component

### DIFF
--- a/src/app/admin/events/event-clone-form.component.html
+++ b/src/app/admin/events/event-clone-form.component.html
@@ -65,20 +65,20 @@
         <div class="col-md-9">
           <bs-datetime name="start"
                        [disable]="model.status === EventStatus.InProgress || model.status === EventStatus.Completed"
-                       formControlName="start"></bs-datetime>
+                       formControlName="start">
+          </bs-datetime>
 
-          <div class="form-errors"
-               *ngIf="eventForm.controls['start'].errors && eventForm.controls['start'].touched">
+          <div class="form-errors" *ngIf="eventForm.controls['start'].errors && eventForm.controls['start'].touched">
             <div class="form-control-feedback" *ngIf="eventForm.controls['start'].errors['required']">
               {{ 'T_FORM_FIELD_IS_REQUIRED' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['start'].errors['format']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['start'].errors['required'] && eventForm.controls['start'].errors['format']">
               {{ 'T_ERROR_INVALID_DATE' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['start'].errors['maxDate']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['start'].errors['format'] && eventForm.controls['start'].errors['maxDate']">
               {{ 'T_ERROR_MIN_DATE' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['start'].errors['dateInPast']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['start'].errors['format'] && eventForm.controls['start'].errors['dateInPast']">
               {{ 'T_ERROR_DATE_IN_PAST' | translate }}
             </div>
           </div>
@@ -95,20 +95,18 @@
                        [disable]="model.status === EventStatus.Completed"
                        formControlName="end">
           </bs-datetime>
-          <div class="form-errors"
-               *ngIf="eventForm.controls['end'].errors && eventForm.controls['end'].touched">
-            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['required']">{{
-              'T_FORM_FIELD_IS_REQUIRED' |
-              translate }}
+
+          <div class="form-errors" *ngIf="eventForm.controls['end'].errors && eventForm.controls['end'].touched">
+            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['required']">
+              {{'T_FORM_FIELD_IS_REQUIRED' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['format']"> {{
-              'T_ERROR_INVALID_DATE' | translate
-              }}
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['end'].errors['required'] && eventForm.controls['end'].errors['format']">
+              {{ 'T_ERROR_INVALID_DATE' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['minDate']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['end'].errors['format'] && eventForm.controls['end'].errors['minDate']">
               {{ 'T_ERROR_MAX_DATE' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['dateInPast']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['end'].errors['format'] && eventForm.controls['end'].errors['dateInPast']">
               {{ 'T_ERROR_DATE_IN_PAST' | translate }}
             </div>
           </div>

--- a/src/app/admin/events/event-form.component.html
+++ b/src/app/admin/events/event-form.component.html
@@ -63,20 +63,20 @@
         <div class="col-md-9">
           <bs-datetime name="start"
                        [disable]="model.status === EventStatus.InProgress || model.status === EventStatus.Completed"
-                       formControlName="start"></bs-datetime>
+                       formControlName="start">
+          </bs-datetime>
 
-          <div class="form-errors"
-               *ngIf="eventForm.controls['start'].errors && eventForm.controls['start'].touched">
+          <div class="form-errors" *ngIf="eventForm.controls['start'].errors && eventForm.controls['start'].touched">
             <div class="form-control-feedback" *ngIf="eventForm.controls['start'].errors['required']">
               {{ 'T_FORM_FIELD_IS_REQUIRED' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['start'].errors['format']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['start'].errors['required'] && eventForm.controls['start'].errors['format']">
               {{ 'T_ERROR_INVALID_DATE' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['start'].errors['maxDate']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['start'].errors['format'] && eventForm.controls['start'].errors['maxDate']">
               {{ 'T_ERROR_MIN_DATE' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['start'].errors['dateInPast']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['start'].errors['format'] && eventForm.controls['start'].errors['dateInPast']">
               {{ 'T_ERROR_DATE_IN_PAST' | translate }}
             </div>
           </div>
@@ -93,20 +93,18 @@
                        [disable]="model.status === EventStatus.Completed"
                        formControlName="end">
           </bs-datetime>
-          <div class="form-errors"
-               *ngIf="eventForm.controls['end'].errors && eventForm.controls['end'].touched">
-            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['required']">{{
-              'T_FORM_FIELD_IS_REQUIRED' |
-              translate }}
+
+          <div class="form-errors" *ngIf="eventForm.controls['end'].errors && eventForm.controls['end'].touched">
+            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['required']">
+              {{'T_FORM_FIELD_IS_REQUIRED' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['format']"> {{
-              'T_ERROR_INVALID_DATE' | translate
-              }}
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['end'].errors['required'] && eventForm.controls['end'].errors['format']">
+              {{ 'T_ERROR_INVALID_DATE' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['minDate']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['end'].errors['format'] && eventForm.controls['end'].errors['minDate']">
               {{ 'T_ERROR_MAX_DATE' | translate }}
             </div>
-            <div class="form-control-feedback" *ngIf="eventForm.controls['end'].errors['dateInPast']">
+            <div class="form-control-feedback" *ngIf="!eventForm.controls['end'].errors['format'] && eventForm.controls['end'].errors['dateInPast']">
               {{ 'T_ERROR_DATE_IN_PAST' | translate }}
             </div>
           </div>

--- a/src/app/admin/events/event-notifications-edit-modal.component.html
+++ b/src/app/admin/events/event-notifications-edit-modal.component.html
@@ -40,16 +40,17 @@
             <div class="col-8">
               <bs-datetime #time
                            name="notification-time"
-                           formControlName="time"></bs-datetime>
-              <div class="form-errors"
-                   *ngIf="notificationForm.controls['time'].errors && notificationForm.controls['time'].touched">
+                           formControlName="time">
+              </bs-datetime>
+
+              <div class="form-errors" *ngIf="notificationForm.controls['time'].errors && notificationForm.controls['time'].touched">
                 <div class="form-control-feedback" *ngIf="notificationForm.controls['time'].errors['required']">
                   {{ 'T_FORM_FIELD_IS_REQUIRED' | translate }}
                 </div>
-                <div class="form-control-feedback" *ngIf="notificationForm.controls['time'].errors['format']">
+                <div class="form-control-feedback" *ngIf="!notificationForm.controls['time'].errors['required'] && notificationForm.controls['time'].errors['format']">
                   {{ 'T_ERROR_INVALID_DATE' | translate }}
                 </div>
-                <div class="form-control-feedback" *ngIf="notificationForm.controls['time'].errors['dateInPast']">
+                <div class="form-control-feedback" *ngIf="!notificationForm.controls['time'].errors['format'] && notificationForm.controls['time'].errors['dateInPast']">
                   {{ 'T_ERROR_DATE_IN_PAST' | translate }}
                 </div>
               </div>

--- a/src/app/shared/components/datetime/datetime-picker.component.html
+++ b/src/app/shared/components/datetime/datetime-picker.component.html
@@ -14,8 +14,9 @@
 
 <div class="input-group">
   <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
-  <input type="text"
-         #input
+  <input #input
+         readonly
+         type="text"
          id="datepicker-{{id}}"
          name="datepicker-{{id}}"
          class="form-control"

--- a/src/app/shared/components/datetime/datetime-picker.component.scss
+++ b/src/app/shared/components/datetime/datetime-picker.component.scss
@@ -1,0 +1,4 @@
+input[type="text"].form-control[readonly]:not(:disabled) {
+  background: #fff;
+  cursor: pointer;
+}


### PR DESCRIPTION
__Prohibit the ability to enter invalid characters__
Solution: Provided suggestions in issue are take more over-engineering job like create regexp mask, capture events from input, syncing somehow with jquery plugin and angular component. Instead of this I implement input as readonly.
Pros: 
- Keep text field as display area;
- All work around dates would be flow via internal jquery plugin;
- No more side-effects from input itself.

This solution with readonly is widely used, and as one of example of it is airbnb form of searching.

__Display only 1 error for a field at a time__
Solution: added priority based errors output inside template via additional condition